### PR TITLE
Remove daily planner prefill

### DIFF
--- a/db/db_functions.py
+++ b/db/db_functions.py
@@ -500,6 +500,13 @@ class DailyPlanner:
         else:
             query = "SELECT * FROM daily_planner ORDER BY day"
             return self.db.execute_query(query, fetch=True)
+
+    def read_range(self, start_day, end_day):
+        """Read planner entries within a date range (inclusive)."""
+        start_str = start_day.strftime('%Y-%m-%d') if isinstance(start_day, date) else start_day
+        end_str = end_day.strftime('%Y-%m-%d') if isinstance(end_day, date) else end_day
+        query = "SELECT * FROM daily_planner WHERE day BETWEEN ? AND ? ORDER BY day"
+        return self.db.execute_query(query, (start_str, end_str), fetch=True)
     
     def update(self, day, notes=None, meal_ids=None):
         updates = []

--- a/debug/reset_db.py
+++ b/debug/reset_db.py
@@ -744,19 +744,13 @@ Dislikes:
                 print(f"[FAIL] Failed to add meal idea: {name}")
     
     def load_daily_planner(self):
-        """Loads sample data into the daily_planner table for 2025."""
+        """Ensure the daily_planner table exists."""
         print("\nLoading daily planner...")
-        
-        # Insert entries for each day of 2025
-        start_date = datetime(2025, 1, 1).date()
-        end_date = datetime(2025, 12, 31).date()
-        current_date = start_date
-        
-        while current_date <= end_date:
-            success = self.tables["daily_planner"].create(current_date, None, [])
-            current_date += timedelta(days=1)
-        
-        print("[OK] Daily planner populated for 2025")
+
+        # Simply create the table without pre-populating every day
+        self.tables["daily_planner"].create_table()
+
+        print("[OK] Daily planner table ready")
     
     def load_shopping_list(self):
         """Loads sample items into the shopping_list table."""

--- a/helpers/pull_helper.py
+++ b/helpers/pull_helper.py
@@ -167,8 +167,9 @@ class PullHelper:
             today = date.today()
             tomorrow = today + timedelta(days=1)
             end_date = today + timedelta(days=7)
-            
-            all_entries = daily_planner_table.read()
+
+            # Query only the upcoming week directly
+            all_entries = daily_planner_table.read_range(today, end_date)
             if not all_entries:
                 return "No meal plans found for the upcoming week."
                 

--- a/test_mcp_tools_full.py
+++ b/test_mcp_tools_full.py
@@ -13,30 +13,32 @@ from debug.reset_db import reset_database
 from db.db_functions import Database, Inventory, TasteProfile, SavedMeals, ShoppingList, DailyPlanner, NewMealIdeas
 
 SERVER_SCRIPT = "mcp_server.py"
-SERVER_URL = "http://localhost:8000/mcp"
+# FastMCP server now runs using SSE at the /sse endpoint
+SERVER_URL = "http://localhost:8000/sse"
 
 class SimpleAgent:
     """Very basic agent that maps keyword phrases to MCP tools."""
 
     def __init__(self, client: Client):
         self.client = client
+        # Tool names are namespaced by server prefix (pull, push, action)
         self.tool_map = {
-            "inventory context": "get_inventory_context",
-            "taste profile": "get_taste_profile_context",
-            "saved meals": "get_saved_meals_context",
-            "shopping list": "get_shopping_list_context",
-            "daily plan": "get_daily_notes_context",
-            "meal ideas": "get_new_meal_ideas_context",
-            "meals i can make": "get_instock_meals_context",
-            "ingredient info": "get_ingredients_info_context",
-            "add to inventory": "update_inventory",
-            "change taste": "update_taste_profile",
-            "save meal": "update_saved_meals",
-            "shopping add": "update_shopping_list",
-            "plan update": "update_daily_plan",
-            "plan meals": "run_meal_planner",
-            "suggest meal": "run_meal_suggestion_generator",
-            "new recipe": "run_new_meal_ideator",
+            "inventory context": "pull_get_inventory_context",
+            "taste profile": "pull_get_taste_profile_context",
+            "saved meals": "pull_get_saved_meals_context",
+            "shopping list": "pull_get_shopping_list_context",
+            "daily plan": "pull_get_daily_notes_context",
+            "meal ideas": "pull_get_new_meal_ideas_context",
+            "meals i can make": "pull_get_instock_meals_context",
+            "ingredient info": "pull_get_ingredients_info_context",
+            "add to inventory": "push_update_inventory",
+            "change taste": "push_update_taste_profile",
+            "save meal": "push_update_saved_meals",
+            "shopping add": "push_update_shopping_list",
+            "plan update": "push_update_daily_plan",
+            "plan meals": "action_run_meal_planner",
+            "suggest meal": "action_run_meal_suggestion_generator",
+            "new recipe": "action_run_new_meal_ideator",
         }
 
     async def run(self, prompt: str) -> str:
@@ -50,9 +52,9 @@ class SimpleAgent:
             return "(no tool matched)"
 
         args = {}
-        if tool in {"update_inventory", "update_saved_meals", "update_shopping_list", "update_daily_plan"}:
+        if tool in {"push_update_inventory", "push_update_saved_meals", "push_update_shopping_list", "push_update_daily_plan"}:
             args["user_input"] = prompt
-        elif tool in {"update_taste_profile", "run_meal_planner", "run_meal_suggestion_generator", "run_new_meal_ideator"}:
+        elif tool in {"push_update_taste_profile", "action_run_meal_planner", "action_run_meal_suggestion_generator", "action_run_new_meal_ideator"}:
             args["user_request"] = prompt
         
         result = await self.client.call_tool(tool, args)

--- a/tools/meal_planner.py
+++ b/tools/meal_planner.py
@@ -166,16 +166,22 @@ class OriginalGenerator:
         
         current_date = extended_start
         while current_date <= extended_end:
-            # Check if there's an entry for this date
             existing = self.tables["daily_planner"].read(current_date)
             if existing:
-                # Clear the entry
+                # Clear existing entry
                 self.tables["daily_planner"].update(
                     day=current_date,
                     notes="",
                     meal_ids=json.dumps([])
                 )
                 print(f"Cleared daily planner entry for {current_date.strftime('%Y-%m-%d')}")
+            else:
+                # Create an empty entry so future planning has a row to update
+                self.tables["daily_planner"].create(
+                    day=current_date,
+                    notes="",
+                    meal_ids=json.dumps([])
+                )
             current_date += timedelta(days=1)
         
         print(f"Cleared date range from {extended_start.strftime('%Y-%m-%d')} to {extended_end.strftime('%Y-%m-%d')}")


### PR DESCRIPTION
## Summary
- avoid creating daily planner entries for every day in 2025
- create missing empty planner rows when clearing ranges
- support date range queries for the planner
- limit daily notes context query to upcoming week
- update test script to use SSE endpoint and namespaced tool names

## Testing
- `python test_mcp_tools_full.py` *(fails: OpenAI ChatCompletion not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68876f7cbbf08320a91cb0c4648cab6f